### PR TITLE
Perf disable initilization of implementation

### DIFF
--- a/src/extensions/SupplyVault.sol
+++ b/src/extensions/SupplyVault.sol
@@ -36,9 +36,12 @@ contract SupplyVault is ISupplyVault, ERC4626UpgradeableSafe, OwnableUpgradeable
     /* CONSTRUCTOR */
 
     /// @dev Initializes network-wide immutables.
+    /// @dev The implementation contract disables initialization upon deployment to avoid being hijacked.
     /// @param morpho The address of the main Morpho contract.
     constructor(address morpho) {
         if (morpho == address(0)) revert ZeroAddress();
+
+        _disableInitializers();
         _MORPHO = IMorpho(morpho);
     }
 


### PR DESCRIPTION
This PR is not needed as is (because there's no delegate call), but it's safer IMO
