### PR TITLE
fix(bulker): missleading comment

### DIFF
--- a/src/extensions/BulkerGateway.sol
+++ b/src/extensions/BulkerGateway.sol
@@ -81,7 +81,7 @@ contract BulkerGateway is IBulkerGateway {
         }
     }
 
-    /// @dev Only the WETH contract is allowed to transfer ETH to this contract.
+    /// @dev Only the WETH contract is allowed to transfer ETH to this contract, without any calldata.
     receive() external payable {
         if (msg.sender != _WETH) revert OnlyWETH();
     }


### PR DESCRIPTION
# Pull Request

Since a user could send ETH value to wrap eth, the comment is no longer accurate.