### PR TITLE
Fix miscellaneous Spearbit issues

### DIFF
--- a/src/extensions/BulkerGateway.sol
+++ b/src/extensions/BulkerGateway.sol
@@ -162,6 +162,8 @@ contract BulkerGateway is IBulkerGateway {
     function _supply(bytes calldata data) internal {
         (address asset, uint256 amount, address onBehalf, uint256 maxIterations) =
             abi.decode(data, (address, uint256, address, uint256));
+        if (onBehalf == address(this)) revert AddressIsBulker();
+
         amount = Math.min(amount, ERC20(asset).balanceOf(address(this)));
         if (amount == 0) revert AmountIsZero();
 
@@ -173,6 +175,8 @@ contract BulkerGateway is IBulkerGateway {
     /// @dev Supplies `amount` of `asset` collateral to the pool on behalf of `onBehalf`.
     function _supplyCollateral(bytes calldata data) internal {
         (address asset, uint256 amount, address onBehalf) = abi.decode(data, (address, uint256, address));
+        if (onBehalf == address(this)) revert AddressIsBulker();
+
         amount = Math.min(amount, ERC20(asset).balanceOf(address(this)));
         if (amount == 0) revert AmountIsZero();
 
@@ -193,6 +197,8 @@ contract BulkerGateway is IBulkerGateway {
     /// @dev Repays `amount` of `asset` on behalf of `onBehalf`.
     function _repay(bytes calldata data) internal {
         (address asset, uint256 amount, address onBehalf) = abi.decode(data, (address, uint256, address));
+        if (onBehalf == address(this)) revert AddressIsBulker();
+
         amount = Math.min(amount, ERC20(asset).balanceOf(address(this)));
         if (amount == 0) revert AmountIsZero();
 
@@ -231,7 +237,7 @@ contract BulkerGateway is IBulkerGateway {
     /// @dev Unwraps the given input of WETH to ETH.
     function _unwrapEth(bytes calldata data) internal {
         (uint256 amount, address receiver) = abi.decode(data, (uint256, address));
-        if (receiver == address(this)) revert TransferToSelf();
+        if (receiver == address(this)) revert AddressIsBulker();
         if (receiver == address(0)) revert AddressIsZero();
 
         amount = Math.min(amount, ERC20(_WETH).balanceOf(address(this)));
@@ -255,7 +261,7 @@ contract BulkerGateway is IBulkerGateway {
     /// @dev Unwraps the given input of wstETH to stETH.
     function _unwrapStEth(bytes calldata data) internal {
         (uint256 amount, address receiver) = abi.decode(data, (uint256, address));
-        if (receiver == address(this)) revert TransferToSelf();
+        if (receiver == address(this)) revert AddressIsBulker();
         if (receiver == address(0)) revert AddressIsZero();
 
         amount = Math.min(amount, ERC20(_WST_ETH).balanceOf(address(this)));
@@ -269,7 +275,7 @@ contract BulkerGateway is IBulkerGateway {
     /// @dev Sends any ERC20 in this contract to the receiver.
     function _skim(bytes calldata data) internal {
         (address asset, address receiver) = abi.decode(data, (address, address));
-        if (receiver == address(this)) revert TransferToSelf();
+        if (receiver == address(this)) revert AddressIsBulker();
         if (receiver == address(0)) revert AddressIsZero();
 
         uint256 balance = ERC20(asset).balanceOf(address(this));
@@ -279,6 +285,8 @@ contract BulkerGateway is IBulkerGateway {
     /// @dev Claims rewards for the given assets, on behalf of an address, sending the funds to the given address.
     function _claimRewards(bytes calldata data) internal {
         (address[] memory assets, address onBehalf) = abi.decode(data, (address[], address));
+        if (onBehalf == address(this)) revert AddressIsBulker();
+
         _MORPHO.claimRewards(assets, onBehalf);
     }
 

--- a/src/extensions/BulkerGateway.sol
+++ b/src/extensions/BulkerGateway.sol
@@ -221,6 +221,7 @@ contract BulkerGateway is IBulkerGateway {
     /// @dev Wraps the given input of ETH to WETH.
     function _wrapEth(bytes calldata data) internal {
         (uint256 amount) = abi.decode(data, (uint256));
+
         amount = Math.min(amount, address(this).balance);
         if (amount == 0) revert AmountIsZero();
 
@@ -231,6 +232,8 @@ contract BulkerGateway is IBulkerGateway {
     function _unwrapEth(bytes calldata data) internal {
         (uint256 amount, address receiver) = abi.decode(data, (uint256, address));
         if (receiver == address(this)) revert TransferToSelf();
+        if (receiver == address(0)) revert AddressIsZero();
+
         amount = Math.min(amount, ERC20(_WETH).balanceOf(address(this)));
         if (amount == 0) revert AmountIsZero();
 
@@ -242,6 +245,7 @@ contract BulkerGateway is IBulkerGateway {
     /// @dev Wraps the given input of stETH to wstETH.
     function _wrapStEth(bytes calldata data) internal {
         (uint256 amount) = abi.decode(data, (uint256));
+
         amount = Math.min(amount, ERC20(_ST_ETH).balanceOf(address(this)));
         if (amount == 0) revert AmountIsZero();
 
@@ -252,6 +256,8 @@ contract BulkerGateway is IBulkerGateway {
     function _unwrapStEth(bytes calldata data) internal {
         (uint256 amount, address receiver) = abi.decode(data, (uint256, address));
         if (receiver == address(this)) revert TransferToSelf();
+        if (receiver == address(0)) revert AddressIsZero();
+
         amount = Math.min(amount, ERC20(_WST_ETH).balanceOf(address(this)));
         if (amount == 0) revert AmountIsZero();
 
@@ -264,6 +270,8 @@ contract BulkerGateway is IBulkerGateway {
     function _skim(bytes calldata data) internal {
         (address asset, address receiver) = abi.decode(data, (address, address));
         if (receiver == address(this)) revert TransferToSelf();
+        if (receiver == address(0)) revert AddressIsZero();
+
         uint256 balance = ERC20(asset).balanceOf(address(this));
         ERC20(asset).safeTransfer(receiver, balance);
     }

--- a/src/extensions/BulkerGateway.sol
+++ b/src/extensions/BulkerGateway.sol
@@ -165,7 +165,6 @@ contract BulkerGateway is IBulkerGateway {
         if (onBehalf == address(this)) revert AddressIsBulker();
 
         amount = Math.min(amount, ERC20(asset).balanceOf(address(this)));
-        if (amount == 0) revert AmountIsZero();
 
         _approveMaxToMorpho(asset);
 
@@ -178,7 +177,6 @@ contract BulkerGateway is IBulkerGateway {
         if (onBehalf == address(this)) revert AddressIsBulker();
 
         amount = Math.min(amount, ERC20(asset).balanceOf(address(this)));
-        if (amount == 0) revert AmountIsZero();
 
         _approveMaxToMorpho(asset);
 
@@ -189,7 +187,6 @@ contract BulkerGateway is IBulkerGateway {
     function _borrow(bytes calldata data) internal {
         (address asset, uint256 amount, address receiver, uint256 maxIterations) =
             abi.decode(data, (address, uint256, address, uint256));
-        if (amount == 0) revert AmountIsZero();
 
         _MORPHO.borrow(asset, amount, msg.sender, receiver, maxIterations);
     }
@@ -200,7 +197,6 @@ contract BulkerGateway is IBulkerGateway {
         if (onBehalf == address(this)) revert AddressIsBulker();
 
         amount = Math.min(amount, ERC20(asset).balanceOf(address(this)));
-        if (amount == 0) revert AmountIsZero();
 
         _approveMaxToMorpho(asset);
 
@@ -211,7 +207,6 @@ contract BulkerGateway is IBulkerGateway {
     function _withdraw(bytes calldata data) internal {
         (address asset, uint256 amount, address receiver, uint256 maxIterations) =
             abi.decode(data, (address, uint256, address, uint256));
-        if (amount == 0) revert AmountIsZero();
 
         _MORPHO.withdraw(asset, amount, msg.sender, receiver, maxIterations);
     }
@@ -219,7 +214,6 @@ contract BulkerGateway is IBulkerGateway {
     /// @dev Withdraws `amount` of `asset` on behalf of sender. Sender must have previously approved the bulker as their manager on Morpho.
     function _withdrawCollateral(bytes calldata data) internal {
         (address asset, uint256 amount, address receiver) = abi.decode(data, (address, uint256, address));
-        if (amount == 0) revert AmountIsZero();
 
         _MORPHO.withdrawCollateral(asset, amount, msg.sender, receiver);
     }

--- a/src/extensions/SupplyVault.sol
+++ b/src/extensions/SupplyVault.sol
@@ -39,7 +39,7 @@ contract SupplyVault is ISupplyVault, ERC4626UpgradeableSafe, Ownable2StepUpgrad
     /// @dev The implementation contract disables initialization upon deployment to avoid being hijacked.
     /// @param morpho The address of the main Morpho contract.
     constructor(address morpho) {
-        if (morpho == address(0)) revert ZeroAddress();
+        if (morpho == address(0)) revert AddressIsZero();
 
         _disableInitializers();
         _MORPHO = IMorpho(morpho);
@@ -62,7 +62,8 @@ contract SupplyVault is ISupplyVault, ERC4626UpgradeableSafe, Ownable2StepUpgrad
         uint256 initialDeposit,
         uint96 newMaxIterations
     ) external initializer {
-        if (newUnderlying == address(0)) revert ZeroAddress();
+        if (newUnderlying == address(0)) revert AddressIsZero();
+        if (initialDeposit == 0) revert InitialDepositIsZero();
 
         _underlying = newUnderlying;
         _recipient = newRecipient;
@@ -83,7 +84,7 @@ contract SupplyVault is ISupplyVault, ERC4626UpgradeableSafe, Ownable2StepUpgrad
     ///      The vault is not intended to hold any ERC20 tokens between calls.
     function skim(address[] calldata tokens) external {
         address recipientMem = _recipient;
-        if (recipientMem == address(0)) revert ZeroAddress();
+        if (recipientMem == address(0)) revert AddressIsZero();
 
         for (uint256 i; i < tokens.length; i++) {
             address token = tokens[i];

--- a/src/extensions/SupplyVault.sol
+++ b/src/extensions/SupplyVault.sol
@@ -147,7 +147,7 @@ contract SupplyVault is ISupplyVault, ERC4626UpgradeableSafe, Ownable2StepUpgrad
         virtual
         override
     {
-        _MORPHO.withdraw(_underlying, assets, address(this), address(this), uint256(_maxIterations));
+        assets = _MORPHO.withdraw(_underlying, assets, address(this), address(this), uint256(_maxIterations));
         super._withdraw(caller, receiver, owner, assets, shares);
     }
 

--- a/src/extensions/SupplyVault.sol
+++ b/src/extensions/SupplyVault.sol
@@ -66,8 +66,8 @@ contract SupplyVault is ISupplyVault, ERC4626UpgradeableSafe, Ownable2StepUpgrad
         if (initialDeposit == 0) revert InitialDepositIsZero();
 
         _underlying = newUnderlying;
-        _recipient = newRecipient;
-        _maxIterations = newMaxIterations;
+        _setRecipient(newRecipient);
+        _setMaxIterations(newMaxIterations);
 
         ERC20(newUnderlying).safeApprove(address(_MORPHO), type(uint256).max);
 
@@ -96,14 +96,12 @@ contract SupplyVault is ISupplyVault, ERC4626UpgradeableSafe, Ownable2StepUpgrad
 
     /// @notice Sets the max iterations to use when this vault interacts with Morpho.
     function setMaxIterations(uint96 newMaxIterations) external onlyOwner {
-        _maxIterations = newMaxIterations;
-        emit MaxIterationsSet(newMaxIterations);
+        _setMaxIterations(newMaxIterations);
     }
 
     /// @notice Sets the recipient for the skim function.
     function setRecipient(address newRecipient) external onlyOwner {
-        _recipient = newRecipient;
-        emit RecipientSet(newRecipient);
+        _setRecipient(newRecipient);
     }
 
     /// @notice The address of the Morpho contract this vault utilizes.
@@ -149,6 +147,18 @@ contract SupplyVault is ISupplyVault, ERC4626UpgradeableSafe, Ownable2StepUpgrad
     {
         assets = _MORPHO.withdraw(_underlying, assets, address(this), address(this), uint256(_maxIterations));
         super._withdraw(caller, receiver, owner, assets, shares);
+    }
+
+    /// @dev Sets the max iterations to use when this vault interacts with Morpho.
+    function _setMaxIterations(uint96 newMaxIterations) internal {
+        _maxIterations = newMaxIterations;
+        emit MaxIterationsSet(newMaxIterations);
+    }
+
+    /// @dev Sets the recipient for the skim function.
+    function _setRecipient(address newRecipient) internal {
+        _recipient = newRecipient;
+        emit RecipientSet(newRecipient);
     }
 
     /// @dev This empty reserved space is put in place to allow future versions to add new

--- a/src/interfaces/extensions/IBulkerGateway.sol
+++ b/src/interfaces/extensions/IBulkerGateway.sol
@@ -4,10 +4,6 @@ pragma solidity >=0.5.0;
 interface IBulkerGateway {
     /* ERRORS */
 
-    /// @notice Thrown when an unknown address is about to be approved.
-    /// @param spender The address of the unsafe spender.
-    error UnsafeApproval(address spender);
-
     /// @notice Thrown when execution parameters don't have the same length.
     /// @param nbActions The number of input actions.
     /// @param nbData The number of data inputs.

--- a/src/interfaces/extensions/IBulkerGateway.sol
+++ b/src/interfaces/extensions/IBulkerGateway.sol
@@ -12,13 +12,13 @@ interface IBulkerGateway {
     /// @notice Thrown when another address than WETH sends ETH to the contract.
     error OnlyWETH();
 
-    /// @notice Thrown when an address parameter is the zero address.
+    /// @notice Thrown when an address passed as parameter is the zero address.
     error AddressIsZero();
 
     /// @notice Thrown when an address parameter is the bulker's address.
     error AddressIsBulker();
 
-    /// @notice Thrown when the amount used is zero.
+    /// @notice Thrown when an amount passed as parameter is zero.
     error AmountIsZero();
 
     /// @notice Thrown when the action is unsupported.

--- a/src/interfaces/extensions/IBulkerGateway.sol
+++ b/src/interfaces/extensions/IBulkerGateway.sol
@@ -12,14 +12,14 @@ interface IBulkerGateway {
     /// @notice Thrown when another address than WETH sends ETH to the contract.
     error OnlyWETH();
 
-    /// @notice Thrown when the `morpho` address passed in the constructor is zero.
+    /// @notice Thrown when an address parameter is the zero address.
     error AddressIsZero();
+
+    /// @notice Thrown when an address parameter is the bulker's address.
+    error AddressIsBulker();
 
     /// @notice Thrown when the amount used is zero.
     error AmountIsZero();
-
-    /// @notice Thrown when transfer is attempted from the bulker to the bulker.
-    error TransferToSelf();
 
     /// @notice Thrown when the action is unsupported.
     error UnsupportedAction(ActionType action);

--- a/src/interfaces/extensions/ISupplyVault.sol
+++ b/src/interfaces/extensions/ISupplyVault.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.5.0;
 
 import {IERC4626Upgradeable} from "@openzeppelin-upgradeable/interfaces/IERC4626Upgradeable.sol";
 import {IMorpho} from "src/interfaces/IMorpho.sol";
-import {ERC20} from "@solmate/utils/SafeTransferLib.sol";
 
 interface ISupplyVault is IERC4626Upgradeable {
     /* EVENTS */
@@ -14,18 +13,21 @@ interface ISupplyVault is IERC4626Upgradeable {
 
     /// @notice Emitted when the recipient is set.
     /// @param recipient The recipient.
-    event RecipientSet(address recipient);
+    event RecipientSet(address indexed recipient);
 
     /// @notice Emitted when tokens are skimmed to `recipient`.
     /// @param token The token being skimmed.
     /// @param recipient The recipient.
-    /// @param amount The amount of rewards transferred.
-    event Skimmed(address token, address recipient, uint256 amount);
+    /// @param amount The amount of tokens transferred.
+    event Skimmed(address indexed token, address indexed recipient, uint256 amount);
 
     /* ERRORS */
 
-    /// @notice Thrown when the zero address is passed as input or is the recipient address when calling `transferRewards`.
-    error ZeroAddress();
+    /// @notice Thrown when an address passed as parameter is the zero address.
+    error AddressIsZero();
+
+    /// @notice Thrown when the initial deposit at initialization is zero.
+    error InitialDepositIsZero();
 
     /* EXTERNAL */
 

--- a/test/extensions/TestIntegrationBulkerGateway.sol
+++ b/test/extensions/TestIntegrationBulkerGateway.sol
@@ -24,7 +24,9 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
 
     SigUtils internal sigUtils;
     IBulkerGateway internal bulker;
+
     address stETH;
+    address wstETH;
 
     event Accrued(
         address indexed asset, address indexed reward, address indexed user, uint256 assetIndex, uint256 rewardsAccrued
@@ -35,6 +37,17 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         bulker = new BulkerGateway(address(morpho));
         sigUtils = new SigUtils(morpho.DOMAIN_SEPARATOR());
         stETH = bulker.stETH();
+        wstETH = bulker.wstETH();
+    }
+
+    function _assumeTarget(address onBehalf) internal {
+        vm.assume(onBehalf != address(0) && onBehalf != address(bulker));
+    }
+
+    function _assumeETHReceiver(address receiver) internal override {
+        super._assumeETHReceiver(receiver);
+
+        vm.assume(receiver != address(bulker));
     }
 
     function testShouldNotDeployWithMorphoAddressIsZero() public {
@@ -95,8 +108,10 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     }
 
     function testBulkerShouldWrapETH(address delegator, uint256 amount) public {
+        _assumeTarget(delegator);
+
         amount = bound(amount, 1, type(uint160).max);
-        deal(delegator, type(uint256).max);
+        deal(delegator, amount);
 
         IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
         bytes[] memory data = new bytes[](1);
@@ -109,8 +124,9 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     }
 
     function testBulkerShouldUnwrapETH(address delegator, uint256 amount, address receiver) public {
-        vm.assume(!Address.isContract(receiver));
-        vm.assume(receiver != address(bulker));
+        _assumeTarget(delegator);
+        _assumeETHReceiver(receiver);
+
         amount = bound(amount, 1, type(uint160).max);
         deal(wNative, amount);
         deal(wNative, address(bulker), amount);
@@ -130,6 +146,8 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     }
 
     function testBulkerUnwrapETHShouldRevertIfReceiverIsZero(address delegator, uint256 amount) public {
+        _assumeTarget(delegator);
+
         address receiver = address(bulker);
         amount = bound(amount, 1, type(uint160).max);
         deal(wNative, amount);
@@ -146,7 +164,8 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     }
 
     function testBulkerShouldWrapStETH(address delegator, uint256 amount) public {
-        vm.assume(delegator != address(0));
+        _assumeTarget(delegator);
+
         amount = bound(amount, 2, ILido(stETH).getCurrentStakeLimit());
         deal(delegator, type(uint256).max);
 
@@ -167,7 +186,9 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     }
 
     function testBulkerShouldUnwrapStETH(address delegator, uint256 amount, address receiver) public {
-        vm.assume(delegator != address(0) && receiver != address(0) && receiver != address(bulker));
+        _assumeTarget(delegator);
+        _assumeETHReceiver(receiver);
+
         amount = bound(amount, 1, IWSTETH(stNative).totalSupply());
         deal(stNative, address(bulker), amount);
 
@@ -186,7 +207,8 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     }
 
     function testBulkerShouldRevertIfReceiverIsBulkerUnwrapStETH(address delegator, uint256 amount) public {
-        vm.assume(delegator != address(0));
+        _assumeTarget(delegator);
+
         address receiver = address(bulker);
         amount = bound(amount, 1, IWSTETH(stNative).totalSupply());
         deal(stNative, address(bulker), amount);
@@ -209,7 +231,9 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         address onBehalf,
         uint256 maxIterations
     ) public {
-        vm.assume(onBehalf != address(0));
+        _assumeTarget(delegator);
+        _assumeTarget(onBehalf);
+
         TestMarket storage market = testMarkets[_randomUnderlying(seed)];
         maxIterations = bound(maxIterations, 1, 10);
         amount = _boundSupply(market, amount);
@@ -235,7 +259,9 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         address onBehalf,
         uint256 maxIterations
     ) public {
-        vm.assume(onBehalf != address(0));
+        _assumeTarget(delegator);
+        _assumeTarget(onBehalf);
+
         TestMarket storage market = testMarkets[_randomCollateral(seed)];
         maxIterations = bound(maxIterations, 1, 10);
         amount = _boundSupply(market, amount);
@@ -261,8 +287,9 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         address receiver,
         uint256 maxIterations
     ) public {
-        // Receiver being fuzzed as this address results in overflow balance.
-        vm.assume(delegator != address(0) && receiver != address(0) && receiver != address(this));
+        _assumeTarget(delegator);
+        _assumeTarget(receiver);
+
         TestMarket storage collateralMarket = testMarkets[_randomCollateral(seed)];
         TestMarket storage borrowedMarket = testMarkets[_randomBorrowableInEMode(seed)];
         maxIterations = bound(maxIterations, 1, 10);
@@ -300,7 +327,9 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         address onBehalf,
         uint256 maxIterations
     ) public {
-        vm.assume(delegator != address(0) && onBehalf != address(0));
+        _assumeTarget(delegator);
+        _assumeTarget(onBehalf);
+
         TestMarket storage borrowedMarket = testMarkets[_randomBorrowableInEMode(seed)];
         maxIterations = bound(maxIterations, 1, 10);
         amount = _boundBorrow(borrowedMarket, amount);
@@ -325,7 +354,9 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         address receiver,
         uint256 maxIterations
     ) public {
-        vm.assume(delegator != address(0) && receiver != address(0));
+        _assumeTarget(delegator);
+        _assumeTarget(receiver);
+
         TestMarket storage market = testMarkets[_randomUnderlying(seed)];
         maxIterations = bound(maxIterations, 1, 10);
         amount = _boundSupply(market, amount);
@@ -355,7 +386,9 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     function testBulkerShouldWithdrawCollateral(uint256 seed, address delegator, uint256 amount, address receiver)
         public
     {
-        vm.assume(delegator != address(0) && receiver != address(0));
+        _assumeTarget(delegator);
+        _assumeTarget(receiver);
+
         TestMarket storage market = testMarkets[_randomCollateral(seed)];
         amount = _boundSupply(market, amount);
 
@@ -379,7 +412,9 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     }
 
     function testBulkerShouldSkim(uint256 seed, address delegator, uint256 amount, address receiver) public {
-        vm.assume(delegator != address(0) && receiver != address(0) && receiver != address(bulker));
+        _assumeTarget(delegator);
+        _assumeTarget(receiver);
+
         TestMarket storage market = testMarkets[_randomUnderlying(seed)];
 
         deal(market.underlying, address(bulker), amount);
@@ -398,7 +433,8 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     }
 
     function testBulkerSkimShouldRevertIfReceiverIsBulker(uint256 seed, address delegator, uint256 amount) public {
-        vm.assume(delegator != address(0));
+        _assumeTarget(delegator);
+
         address receiver = address(bulker);
         TestMarket storage market = testMarkets[_randomUnderlying(seed)];
 
@@ -426,7 +462,8 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     }
 
     function testBulkerClaimRewardsShouldRevertIfRewardsManagerNotSet(address delegator, address onBehalf) public {
-        vm.assume(delegator != address(0) && onBehalf != address(0));
+        _assumeTarget(delegator);
+        _assumeTarget(onBehalf);
 
         address[] memory assets = new address[](1);
         assets[0] = testMarkets[dai].aToken;
@@ -444,7 +481,8 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     }
 
     function testBulkerClaimRewards(address delegator, address onBehalf) public {
-        vm.assume(delegator != address(0) && onBehalf != address(0));
+        _assumeTarget(delegator);
+        _assumeTarget(onBehalf);
 
         rewardsManager = IRewardsManager(new RewardsManagerMock(address(morpho)));
         morpho.setRewardsManager(address(rewardsManager));
@@ -468,6 +506,7 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
     function testMultipleActions(uint256 privateKey, uint256 seed, uint256 amount, uint256 maxIterations) public {
         privateKey = bound(privateKey, 1, type(uint160).max);
         maxIterations = bound(maxIterations, 1, 10);
+
         TestMarket storage market = testMarkets[_randomUnderlying(seed)];
         address delegator = vm.addr(privateKey);
 
@@ -491,6 +530,231 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         assertEq(ERC20(market.underlying).balanceOf(address(bulker)), 0, "bulker balance");
         assertEq(ERC20(market.underlying).balanceOf(address(delegator)), 0, "delegator balance");
         assertApproxEqAbs(morpho.supplyBalance(market.underlying, delegator), amount, 2, "delegator supply");
+    }
+
+    function testBulkerShouldNotWrapEthZero(address delegator, uint256 amount) public {
+        _assumeTarget(delegator);
+
+        amount = bound(amount, 1, type(uint160).max);
+        deal(delegator, amount);
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getWrapETHData(amount);
+
+        vm.prank(delegator);
+        vm.expectRevert(IBulkerGateway.AmountIsZero.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotUnwrapEthZero(address delegator, uint256 amount, address receiver) public {
+        _assumeTarget(delegator);
+        _assumeETHReceiver(receiver);
+
+        amount = bound(amount, 1, type(uint160).max);
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getUnwrapETHData(amount, receiver);
+
+        vm.prank(delegator);
+        vm.expectRevert(IBulkerGateway.AmountIsZero.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotUnwrapEthToBulker(address delegator, uint256 amount) public {
+        _assumeTarget(delegator);
+
+        amount = bound(amount, 1, wNative.balance);
+        deal(wNative, address(bulker), amount);
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getUnwrapETHData(amount, address(bulker));
+
+        vm.prank(delegator);
+        vm.expectRevert(IBulkerGateway.AddressIsBulker.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotUnwrapEthToZeroAddress(address delegator, uint256 amount) public {
+        _assumeTarget(delegator);
+
+        amount = bound(amount, 1, wNative.balance);
+        deal(wNative, address(bulker), amount);
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getUnwrapETHData(amount, address(0));
+
+        vm.prank(delegator);
+        vm.expectRevert(IBulkerGateway.AddressIsZero.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotWrapStEthZero(address delegator, uint256 amount) public {
+        _assumeTarget(delegator);
+
+        amount = bound(amount, 1, type(uint160).max);
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getWrapStETHData(amount);
+
+        vm.prank(delegator);
+        vm.expectRevert(IBulkerGateway.AmountIsZero.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotUnwrapStEthZero(address delegator, uint256 amount, address receiver) public {
+        _assumeTarget(delegator);
+        _assumeETHReceiver(receiver);
+
+        amount = bound(amount, 1, type(uint160).max);
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getUnwrapStETHData(amount, receiver);
+
+        vm.prank(delegator);
+        vm.expectRevert(IBulkerGateway.AmountIsZero.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotUnwrapStEthToBulker(address delegator, uint256 amount) public {
+        _assumeTarget(delegator);
+
+        amount = bound(amount, 1, ERC20(stETH).balanceOf(wstETH));
+        deal(wstETH, address(bulker), amount);
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getUnwrapStETHData(amount, address(bulker));
+
+        vm.prank(delegator);
+        vm.expectRevert(IBulkerGateway.AddressIsBulker.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotUnwrapStEthToZeroAddress(address delegator, uint256 amount) public {
+        _assumeTarget(delegator);
+
+        amount = bound(amount, 1, ERC20(stETH).balanceOf(wstETH));
+        deal(wstETH, address(bulker), amount);
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getUnwrapStETHData(amount, address(0));
+
+        vm.prank(delegator);
+        vm.expectRevert(IBulkerGateway.AddressIsZero.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotSupplyOnBehalfBulker(
+        uint256 seed,
+        address delegator,
+        uint256 amount,
+        uint256 maxIterations
+    ) public {
+        _assumeTarget(delegator);
+
+        TestMarket storage market = testMarkets[_randomUnderlying(seed)];
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getSupplyData(market.underlying, amount, address(bulker), maxIterations);
+
+        vm.startPrank(delegator);
+        vm.expectRevert(IBulkerGateway.AddressIsBulker.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotSupplyCollateralOnBehalfBulker(uint256 seed, address delegator, uint256 amount)
+        public
+    {
+        _assumeTarget(delegator);
+
+        TestMarket storage market = testMarkets[_randomUnderlying(seed)];
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getSupplyCollateralData(market.underlying, amount, address(bulker));
+
+        vm.startPrank(delegator);
+        vm.expectRevert(IBulkerGateway.AddressIsBulker.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotRepayOnBehalfBulker(uint256 seed, address delegator, uint256 amount) public {
+        _assumeTarget(delegator);
+
+        TestMarket storage market = testMarkets[_randomUnderlying(seed)];
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getRepayData(market.underlying, amount, address(bulker));
+
+        vm.startPrank(delegator);
+        vm.expectRevert(IBulkerGateway.AddressIsBulker.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotSkimToBulker(uint256 seed, address delegator) public {
+        _assumeTarget(delegator);
+
+        TestMarket storage market = testMarkets[_randomUnderlying(seed)];
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getSkimData(market.underlying, address(bulker));
+
+        vm.startPrank(delegator);
+        vm.expectRevert(IBulkerGateway.AddressIsBulker.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotSkimToZeroAddress(uint256 seed, address delegator) public {
+        _assumeTarget(delegator);
+
+        TestMarket storage market = testMarkets[_randomUnderlying(seed)];
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getSkimData(market.underlying, address(0));
+
+        vm.startPrank(delegator);
+        vm.expectRevert(IBulkerGateway.AddressIsZero.selector);
+        bulker.execute(actions, data);
+    }
+
+    function testBulkerShouldNotClaimRewardsOnBehalfBulker(address delegator) public {
+        _assumeTarget(delegator);
+
+        address[] memory assets = new address[](1);
+        assets[0] = testMarkets[dai].aToken;
+
+        IBulkerGateway.ActionType[] memory actions = new IBulkerGateway.ActionType[](1);
+        bytes[] memory data = new bytes[](1);
+
+        (actions[0], data[0]) = _getClaimRewardsData(assets, address(bulker));
+
+        vm.prank(delegator);
+        vm.expectRevert(IBulkerGateway.AddressIsBulker.selector);
+        bulker.execute(actions, data);
     }
 
     function _getApproveData(

--- a/test/extensions/TestIntegrationBulkerGateway.sol
+++ b/test/extensions/TestIntegrationBulkerGateway.sol
@@ -44,12 +44,6 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         vm.assume(onBehalf != address(0) && onBehalf != address(bulker));
     }
 
-    function _assumeETHReceiver(address receiver) internal override {
-        super._assumeETHReceiver(receiver);
-
-        vm.assume(receiver != address(bulker));
-    }
-
     function testShouldNotDeployWithMorphoAddressIsZero() public {
         vm.expectRevert(IBulkerGateway.AddressIsZero.selector);
         new BulkerGateway(address(0));
@@ -125,6 +119,7 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
 
     function testBulkerShouldUnwrapETH(address delegator, uint256 amount, address receiver) public {
         _assumeTarget(delegator);
+        _assumeTarget(receiver);
         _assumeETHReceiver(receiver);
 
         amount = bound(amount, 1, type(uint160).max);
@@ -187,7 +182,7 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
 
     function testBulkerShouldUnwrapStETH(address delegator, uint256 amount, address receiver) public {
         _assumeTarget(delegator);
-        _assumeETHReceiver(receiver);
+        _assumeTarget(receiver);
 
         amount = bound(amount, 1, IWSTETH(stNative).totalSupply());
         deal(stNative, address(bulker), amount);
@@ -550,6 +545,7 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
 
     function testBulkerShouldNotUnwrapEthZero(address delegator, uint256 amount, address receiver) public {
         _assumeTarget(delegator);
+        _assumeTarget(receiver);
         _assumeETHReceiver(receiver);
 
         amount = bound(amount, 1, type(uint160).max);
@@ -613,7 +609,7 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
 
     function testBulkerShouldNotUnwrapStEthZero(address delegator, uint256 amount, address receiver) public {
         _assumeTarget(delegator);
-        _assumeETHReceiver(receiver);
+        _assumeTarget(receiver);
 
         amount = bound(amount, 1, type(uint160).max);
 

--- a/test/extensions/TestIntegrationBulkerGateway.sol
+++ b/test/extensions/TestIntegrationBulkerGateway.sol
@@ -40,7 +40,7 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         wstETH = bulker.wstETH();
     }
 
-    function _assumeTarget(address onBehalf) internal {
+    function _assumeTarget(address onBehalf) internal view {
         vm.assume(onBehalf != address(0) && onBehalf != address(bulker));
     }
 

--- a/test/extensions/TestIntegrationBulkerGateway.sol
+++ b/test/extensions/TestIntegrationBulkerGateway.sol
@@ -37,7 +37,7 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         stETH = bulker.stETH();
     }
 
-    function testShouldNotDeployWithMorphoZeroAddress() public {
+    function testShouldNotDeployWithMorphoAddressIsZero() public {
         vm.expectRevert(IBulkerGateway.AddressIsZero.selector);
         new BulkerGateway(address(0));
     }
@@ -141,7 +141,7 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         (actions[0], data[0]) = _getUnwrapETHData(amount, receiver);
 
         vm.prank(delegator);
-        vm.expectRevert(IBulkerGateway.TransferToSelf.selector);
+        vm.expectRevert(IBulkerGateway.AddressIsBulker.selector);
         bulker.execute(actions, data);
     }
 
@@ -198,7 +198,7 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
 
         vm.prank(delegator);
 
-        vm.expectRevert(IBulkerGateway.TransferToSelf.selector);
+        vm.expectRevert(IBulkerGateway.AddressIsBulker.selector);
         bulker.execute(actions, data);
     }
 
@@ -410,7 +410,7 @@ contract TestIntegrationBulkerGateway is IntegrationTest {
         (actions[0], data[0]) = _getSkimData(market.underlying, receiver);
 
         vm.prank(delegator);
-        vm.expectRevert(IBulkerGateway.TransferToSelf.selector);
+        vm.expectRevert(IBulkerGateway.AddressIsBulker.selector);
         bulker.execute(actions, data);
     }
 

--- a/test/extensions/TestIntegrationSupplyVault.sol
+++ b/test/extensions/TestIntegrationSupplyVault.sol
@@ -262,7 +262,7 @@ contract TestIntegrationSupplyVault is TestSetupVaults {
         address[] memory underlyings = new address[](1);
         underlyings[0] = underlying;
 
-        vm.expectRevert(ISupplyVault.ZeroAddress.selector);
+        vm.expectRevert(ISupplyVault.AddressIsZero.selector);
         daiSupplyVault.skim(underlyings);
     }
 

--- a/test/extensions/TestIntegrationSupplyVault.sol
+++ b/test/extensions/TestIntegrationSupplyVault.sol
@@ -16,12 +16,20 @@ contract TestIntegrationSupplyVault is TestSetupVaults {
     }
 
     function testCorrectInitialisationWrappedNative() public {
-        assertEq(wrappedNativeTokenSupplyVault.owner(), address(this));
-        assertEq(wrappedNativeTokenSupplyVault.name(), "MorphoAaveWNATIVE");
-        assertEq(wrappedNativeTokenSupplyVault.symbol(), "maWNATIVE");
-        assertEq(wrappedNativeTokenSupplyVault.underlying(), wNative);
-        assertEq(wrappedNativeTokenSupplyVault.asset(), wNative);
-        assertEq(wrappedNativeTokenSupplyVault.decimals(), 18);
+        assertEq(wNativeSupplyVault.owner(), address(this));
+        assertEq(wNativeSupplyVault.name(), "MorphoAaveWNATIVE");
+        assertEq(wNativeSupplyVault.symbol(), "maWNATIVE");
+        assertEq(wNativeSupplyVault.underlying(), wNative);
+        assertEq(wNativeSupplyVault.asset(), wNative);
+        assertEq(wNativeSupplyVault.decimals(), 18);
+    }
+
+    function testShouldNotAcceptZeroInitialDeposit() public {
+        SupplyVault supplyVault =
+            SupplyVault(address(new TransparentUpgradeableProxy(address(supplyVaultImplV1), address(proxyAdmin), "")));
+
+        vm.expectRevert(ISupplyVault.InitialDepositIsZero.selector);
+        supplyVault.initialize(address(usdc), RECIPIENT, "MorphoAaveUSDC2", "maUSDC2", 0, 4);
     }
 
     function testShouldNotMintZeroShare() public {

--- a/test/extensions/TestIntegrationSupplyVault.sol
+++ b/test/extensions/TestIntegrationSupplyVault.sol
@@ -267,7 +267,7 @@ contract TestIntegrationSupplyVault is TestSetupVaults {
         assertApproxEqAbs(
             ERC20(dai).balanceOf(address(user)) - balanceBefore,
             amount.rayDiv(poolIndexBefore).rayMul(poolIndexAfter),
-            2,
+            3,
             "unexpected withdrawn assets"
         );
     }

--- a/test/extensions/TestIntegrationVaultsUpgradeable.sol
+++ b/test/extensions/TestIntegrationVaultsUpgradeable.sol
@@ -13,8 +13,8 @@ contract TestIntegrationVaultsUpgradeable is TestSetupVaults {
 
         vm.record();
         vm.prank(proxyAdmin.owner());
-        proxyAdmin.upgrade(wrappedNativeTokenSupplyVaultProxy, address(wethSupplyVaultImplV2));
-        (, bytes32[] memory writes) = vm.accesses(address(wrappedNativeTokenSupplyVault));
+        proxyAdmin.upgrade(wNativeSupplyVaultProxy, address(wethSupplyVaultImplV2));
+        (, bytes32[] memory writes) = vm.accesses(address(wNativeSupplyVault));
 
         // 1 write for the implemention.
         assertEq(writes.length, 1);
@@ -22,7 +22,7 @@ contract TestIntegrationVaultsUpgradeable is TestSetupVaults {
             uint160(
                 uint256(
                     vm.load(
-                        address(wrappedNativeTokenSupplyVault),
+                        address(wNativeSupplyVault),
                         bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1) // Implementation slot.
                     )
                 )
@@ -37,10 +37,10 @@ contract TestIntegrationVaultsUpgradeable is TestSetupVaults {
 
         vm.prank(caller);
         vm.expectRevert("Ownable: caller is not the owner");
-        proxyAdmin.upgrade(wrappedNativeTokenSupplyVaultProxy, address(supplyVaultImplV2));
+        proxyAdmin.upgrade(wNativeSupplyVaultProxy, address(supplyVaultImplV2));
 
         vm.prank(proxyAdmin.owner());
-        proxyAdmin.upgrade(wrappedNativeTokenSupplyVaultProxy, address(supplyVaultImplV2));
+        proxyAdmin.upgrade(wNativeSupplyVaultProxy, address(supplyVaultImplV2));
     }
 
     function testOnlyProxyOwnerCanUpgradeAndCallSupplyVault() public {
@@ -50,11 +50,11 @@ contract TestIntegrationVaultsUpgradeable is TestSetupVaults {
 
         vm.prank(address(user));
         vm.expectRevert("Ownable: caller is not the owner");
-        proxyAdmin.upgradeAndCall(wrappedNativeTokenSupplyVaultProxy, payable(address(wethSupplyVaultImplV2)), "");
+        proxyAdmin.upgradeAndCall(wNativeSupplyVaultProxy, payable(address(wethSupplyVaultImplV2)), "");
 
         // Revert for wrong data not wrong caller.
         vm.expectRevert("Address: low-level delegate call failed");
-        proxyAdmin.upgradeAndCall(wrappedNativeTokenSupplyVaultProxy, payable(address(wethSupplyVaultImplV2)), "");
+        proxyAdmin.upgradeAndCall(wNativeSupplyVaultProxy, payable(address(wethSupplyVaultImplV2)), "");
     }
 
     function testSupplyVaultImplementationsShouldBeInitialized() public {
@@ -63,31 +63,31 @@ contract TestIntegrationVaultsUpgradeable is TestSetupVaults {
     }
 
     function testTransferOwnershipRevertsIfNotOwner(address newOwner, address caller) public {
-        vm.assume(caller != wrappedNativeTokenSupplyVault.owner() && caller != address(proxyAdmin));
+        vm.assume(caller != wNativeSupplyVault.owner() && caller != address(proxyAdmin));
         vm.expectRevert("Ownable: caller is not the owner");
         vm.prank(caller);
-        wrappedNativeTokenSupplyVault.transferOwnership(newOwner);
+        wNativeSupplyVault.transferOwnership(newOwner);
     }
 
     function testTransferOwnership(address newOwner) public {
-        wrappedNativeTokenSupplyVault.transferOwnership(newOwner);
-        assertEq(wrappedNativeTokenSupplyVault.pendingOwner(), newOwner);
-        assertEq(wrappedNativeTokenSupplyVault.owner(), address(this));
+        wNativeSupplyVault.transferOwnership(newOwner);
+        assertEq(wNativeSupplyVault.pendingOwner(), newOwner);
+        assertEq(wNativeSupplyVault.owner(), address(this));
     }
 
     function testAcceptOwnershipFailsIfNotPendingOwner(address newOwner, address wrongOwner) public {
         vm.assume(newOwner != wrongOwner);
-        wrappedNativeTokenSupplyVault.transferOwnership(newOwner);
+        wNativeSupplyVault.transferOwnership(newOwner);
         vm.expectRevert("Ownable2Step: caller is not the new owner");
         vm.prank(wrongOwner);
-        wrappedNativeTokenSupplyVault.acceptOwnership();
+        wNativeSupplyVault.acceptOwnership();
     }
 
     function testAcceptOwnership(address newOwner) public {
-        wrappedNativeTokenSupplyVault.transferOwnership(newOwner);
+        wNativeSupplyVault.transferOwnership(newOwner);
         vm.prank(newOwner);
-        wrappedNativeTokenSupplyVault.acceptOwnership();
-        assertEq(wrappedNativeTokenSupplyVault.pendingOwner(), address(0));
-        assertEq(wrappedNativeTokenSupplyVault.owner(), newOwner);
+        wNativeSupplyVault.acceptOwnership();
+        assertEq(wNativeSupplyVault.pendingOwner(), address(0));
+        assertEq(wNativeSupplyVault.owner(), newOwner);
     }
 }

--- a/test/extensions/TestSetupVaults.sol
+++ b/test/extensions/TestSetupVaults.sol
@@ -12,11 +12,11 @@ contract TestSetupVaults is IntegrationTest {
     address internal constant MORPHO_DAO = 0xcBa28b38103307Ec8dA98377ffF9816C164f9AFa;
     address internal constant RECIPIENT = 0x60345417a227ad7E312eAa1B5EC5CD1Fe5E2Cdc6;
 
-    TransparentUpgradeableProxy internal wrappedNativeTokenSupplyVaultProxy;
+    TransparentUpgradeableProxy internal wNativeSupplyVaultProxy;
 
     SupplyVault internal supplyVaultImplV1;
 
-    SupplyVault internal wrappedNativeTokenSupplyVault;
+    SupplyVault internal wNativeSupplyVault;
     SupplyVault internal daiSupplyVault;
     SupplyVault internal usdcSupplyVault;
 
@@ -38,28 +38,37 @@ contract TestSetupVaults is IntegrationTest {
     function initVaultContracts() internal {
         supplyVaultImplV1 = new SupplyVault(address(morpho));
 
-        wrappedNativeTokenSupplyVaultProxy = new TransparentUpgradeableProxy(
+        wNativeSupplyVaultProxy = new TransparentUpgradeableProxy(
             address(supplyVaultImplV1),
             address(proxyAdmin),
             ""
         );
-        wrappedNativeTokenSupplyVault = SupplyVault(address(wrappedNativeTokenSupplyVaultProxy));
-        wrappedNativeTokenSupplyVault.initialize(wNative, RECIPIENT, "MorphoAaveWNATIVE", "maWNATIVE", 0, 4);
-        maWrappedNativeToken = ERC20(address(wrappedNativeTokenSupplyVault));
+        wNativeSupplyVault = SupplyVault(address(wNativeSupplyVaultProxy));
+
+        deal(wNative, address(this), 1e9);
+        ERC20(wNative).safeApprove(address(wNativeSupplyVault), 1e9);
+        wNativeSupplyVault.initialize(wNative, RECIPIENT, "MorphoAaveWNATIVE", "maWNATIVE", 1e9, 4);
+        maWrappedNativeToken = ERC20(address(wNativeSupplyVault));
 
         daiSupplyVault =
             SupplyVault(address(new TransparentUpgradeableProxy(address(supplyVaultImplV1), address(proxyAdmin), "")));
-        daiSupplyVault.initialize(address(dai), RECIPIENT, "MorphoAaveDAI", "maDAI", 0, 4);
+
+        deal(dai, address(this), 1e9);
+        ERC20(dai).safeApprove(address(daiSupplyVault), 1e9);
+        daiSupplyVault.initialize(address(dai), RECIPIENT, "MorphoAaveDAI", "maDAI", 1e9, 4);
         maDai = ERC20(address(daiSupplyVault));
 
         usdcSupplyVault =
             SupplyVault(address(new TransparentUpgradeableProxy(address(supplyVaultImplV1), address(proxyAdmin), "")));
-        usdcSupplyVault.initialize(address(usdc), RECIPIENT, "MorphoAaveUSDC", "maUSDC", 0, 4);
+
+        deal(usdc, address(this), 1e3);
+        ERC20(usdc).safeApprove(address(usdcSupplyVault), 1e3);
+        usdcSupplyVault.initialize(address(usdc), RECIPIENT, "MorphoAaveUSDC", "maUSDC", 1e3, 4);
         maUsdc = ERC20(address(usdcSupplyVault));
     }
 
     function setVaultContractsLabels() internal {
-        vm.label(address(wrappedNativeTokenSupplyVault), "SupplyVault (WNATIVE)");
+        vm.label(address(wNativeSupplyVault), "SupplyVault (WNATIVE)");
         vm.label(address(usdcSupplyVault), "SupplyVault (USDC)");
         vm.label(address(daiSupplyVault), "SupplyVault (DAI)");
     }

--- a/test/helpers/IntegrationTest.sol
+++ b/test/helpers/IntegrationTest.sol
@@ -234,7 +234,7 @@ contract IntegrationTest is ForkTest {
         internal
         bypassSupplyCap(underlying, amount)
     {
-        deal(underlying, address(this), type(uint256).max);
+        _deal(underlying, address(this), amount);
         ERC20(underlying).safeApprove(address(pool), amount);
         pool.deposit(underlying, amount, onBehalf, 0);
     }

--- a/test/integration/TestIntegrationMorphoSetters.sol
+++ b/test/integration/TestIntegrationMorphoSetters.sol
@@ -40,7 +40,7 @@ contract TestIntegrationMorphoSetters is IntegrationTest {
         morpho.createMarket(link, reserveFactor, p2pIndexCursor);
     }
 
-    function testCreateMarketRevertsIfZeroAddressUnderlying(uint16 reserveFactor, uint16 p2pIndexCursor) public {
+    function testCreateMarketRevertsIfAddressIsZeroUnderlying(uint16 reserveFactor, uint16 p2pIndexCursor) public {
         reserveFactor = uint16(bound(reserveFactor, 0, PercentageMath.PERCENTAGE_FACTOR));
         p2pIndexCursor = uint16(bound(p2pIndexCursor, 0, PercentageMath.PERCENTAGE_FACTOR));
         vm.expectRevert(Errors.AddressIsZero.selector);

--- a/test/integration/TestIntegrationWETHGateway.sol
+++ b/test/integration/TestIntegrationWETHGateway.sol
@@ -31,7 +31,7 @@ contract TestIntegrationWETHGateway is IntegrationTest {
         assertEq(ERC20(weth).balanceOf(address(wethGateway)), 0);
     }
 
-    function testShouldNotPassMorphoZeroAddress() public {
+    function testShouldNotPassMorphoAddressIsZero() public {
         vm.expectRevert(Errors.AddressIsZero.selector);
         new WETHGateway(address(0));
     }


### PR DESCRIPTION
- fixes https://github.com/spearbit-audits/review-morpho-june/issues/11

Everytime the bulker interacts with Morpho, early reverts have been remove because they are redundant with the Morpho protocol (`amount != 0`, `receiver != address(0)`, `onBehalf != address(0)`)