### PR TITLE
Correct comment after cache removal

### DIFF
--- a/src/MorphoInternal.sol
+++ b/src/MorphoInternal.sol
@@ -459,7 +459,7 @@ abstract contract MorphoInternal is MorphoStorage {
         _market[underlying].setIndexes(indexes);
     }
 
-    /// @dev Computes the updated indexes of the `underlying` market (if not already updated) and returns them.
+    /// @dev Computes the updated indexes of the `underlying` market and returns them.
     function _computeIndexes(address underlying) internal view returns (Types.Indexes256 memory indexes) {
         Types.Market storage market = _market[underlying];
         Types.Indexes256 memory lastIndexes = market.getIndexes();


### PR DESCRIPTION
The function comments still show that a cache of indexes may be returned, when cache feature has been removed.
