### PR TITLE
Remove claim rewards on behalf

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -258,25 +258,25 @@ contract Morpho is IMorpho, MorphoGetters, MorphoSetters {
 
     /// @notice Claims rewards for the given assets.
     /// @param assets The assets to claim rewards from (aToken or variable debt token).
-    /// @param onBehalf The address for which rewards are claimed and sent to.
+    /// @param receiver The address of the user receiving rewards.
     /// @return rewardTokens The addresses of each reward token.
     /// @return claimedAmounts The amount of rewards claimed (in reward tokens).
-    function claimRewards(address[] calldata assets, address onBehalf)
+    function claimRewards(address[] calldata assets, address receiver)
         external
         returns (address[] memory rewardTokens, uint256[] memory claimedAmounts)
     {
         if (address(_rewardsManager) == address(0)) revert Errors.AddressIsZero();
         if (_isClaimRewardsPaused) revert Errors.ClaimRewardsPaused();
 
-        (rewardTokens, claimedAmounts) = _rewardsManager.claimRewards(assets, onBehalf);
+        (rewardTokens, claimedAmounts) = _rewardsManager.claimRewards(assets, msg.sender);
         IRewardsController(_rewardsManager.REWARDS_CONTROLLER()).claimAllRewardsToSelf(assets);
 
         for (uint256 i; i < rewardTokens.length; ++i) {
             uint256 claimedAmount = claimedAmounts[i];
 
             if (claimedAmount > 0) {
-                ERC20(rewardTokens[i]).safeTransfer(onBehalf, claimedAmount);
-                emit Events.RewardsClaimed(msg.sender, onBehalf, rewardTokens[i], claimedAmount);
+                ERC20(rewardTokens[i]).safeTransfer(receiver, claimedAmount);
+                emit Events.RewardsClaimed(msg.sender, receiver, rewardTokens[i], claimedAmount);
             }
         }
     }

--- a/src/libraries/Events.sol
+++ b/src/libraries/Events.sol
@@ -159,11 +159,11 @@ library Events {
 
     /// @notice Emitted when a rewards are claimed.
     /// @param claimer The address of the user claiming the rewards.
-    /// @param onBehalf The address of the user on behalf of which the rewards are claimed.
+    /// @param receiver The address of the user receiving rewards.
     /// @param rewardToken The address of the reward token claimed.
     /// @param amountClaimed The amount of `rewardToken` claimed.
     event RewardsClaimed(
-        address indexed claimer, address indexed onBehalf, address indexed rewardToken, uint256 amountClaimed
+        address indexed claimer, address indexed receiver, address indexed rewardToken, uint256 amountClaimed
     );
 
     /// @notice Emitted when the collateral status of the `underlying` market is set to `isCollateral`.


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request:

- fixes https://github.com/spearbit-audits/review-morpho-june/issues/30

This is a PR following my analysis in the issue. Note that it removes the possibility to claim rewards on behalf of someone else, which may break current integrations: does Instadapp/Defi Saver smart-contract accounts have ways to claim rewards?