### PR TITLE
refactor(test): revert renaming

### DIFF
--- a/test/helpers/BaseTest.sol
+++ b/test/helpers/BaseTest.sol
@@ -74,7 +74,7 @@ contract BaseTest is Test {
     }
 
     /// @dev Bounds the fuzzing input to a non-zero address.
-    function _boundAddressNotInvalid(address input) internal view virtual returns (address) {
+    function _boundAddressNotZero(address input) internal view virtual returns (address) {
         return address(uint160(bound(uint256(uint160(input)), 1, type(uint160).max)));
     }
 

--- a/test/helpers/IntegrationTest.sol
+++ b/test/helpers/IntegrationTest.sol
@@ -463,8 +463,8 @@ contract IntegrationTest is ForkTest {
         return amount;
     }
 
-    function _boundAddressNotInvalid(address input) internal view virtual override returns (address) {
-        input = super._boundAddressNotInvalid(input);
+    function _boundAddressNotInvalid(address input) internal view virtual returns (address) {
+        input = _boundAddressNotZero(input);
 
         vm.assume(input != address(proxyAdmin)); // TransparentUpgradeableProxy: admin cannot fallback to proxy target.
         vm.assume(input != 0x807a96288A1A408dBC13DE2b1d087d10356395d2); // Proxy admin for USDC.

--- a/test/helpers/IntegrationTest.sol
+++ b/test/helpers/IntegrationTest.sol
@@ -463,7 +463,7 @@ contract IntegrationTest is ForkTest {
         return amount;
     }
 
-    function _boundAddressNotInvalid(address input) internal view virtual returns (address) {
+    function _boundAddressValid(address input) internal view virtual returns (address) {
         input = _boundAddressNotZero(input);
 
         vm.assume(input != address(proxyAdmin)); // TransparentUpgradeableProxy: admin cannot fallback to proxy target.
@@ -473,13 +473,13 @@ contract IntegrationTest is ForkTest {
     }
 
     function _boundOnBehalf(address onBehalf) internal view returns (address) {
-        onBehalf = _boundAddressNotInvalid(onBehalf);
+        onBehalf = _boundAddressValid(onBehalf);
 
         return onBehalf;
     }
 
     function _boundReceiver(address input) internal view returns (address output) {
-        output = _boundAddressNotInvalid(input);
+        output = _boundAddressValid(input);
 
         vm.assume(output != address(this));
 

--- a/test/integration/TestIntegrationAssetAsCollateral.sol
+++ b/test/integration/TestIntegrationAssetAsCollateral.sol
@@ -43,6 +43,7 @@ contract TestIntegrationAssetAsCollateral is IntegrationTest {
     }
 
     function testSetAssetIsCollateralShouldRevertWhenMarketNotCreated(address underlying) public {
+        _assumeNotUnderlying(underlying);
         vm.expectRevert(Errors.MarketNotCreated.selector);
         morpho.setAssetIsCollateral(underlying, true);
     }

--- a/test/integration/TestIntegrationClaimToTreasury.sol
+++ b/test/integration/TestIntegrationClaimToTreasury.sol
@@ -22,7 +22,7 @@ contract TestIntegrationClaimToTreasury is IntegrationTest {
     }
 
     function testShouldNotClaimToTreasuryIfMarketNotCreated(address treasuryVault, uint8 nbUnderlyings) public {
-        treasuryVault = _boundAddressNotInvalid(treasuryVault);
+        treasuryVault = _boundAddressValid(treasuryVault);
         vm.assume(treasuryVault != address(morpho));
 
         address[] memory claimedUnderlyings = new address[](nbUnderlyings);

--- a/test/integration/TestIntegrationPermit2.sol
+++ b/test/integration/TestIntegrationPermit2.sol
@@ -291,7 +291,7 @@ contract TestIntegrationPermit2 is IntegrationTest {
         deadline = bound(deadline, block.timestamp, type(uint32).max);
         privateKey = bound(privateKey, 1, type(uint160).max);
         address delegator = vm.addr(privateKey);
-        pranker = _boundAddressNotInvalid(pranker);
+        pranker = _boundAddressValid(pranker);
         vm.assume(pranker != delegator && pranker.code.length == 0);
 
         TestMarket storage market = testMarkets[_randomUnderlying(seed)];

--- a/test/integration/TestIntegrationSupplyCollateral.sol
+++ b/test/integration/TestIntegrationSupplyCollateral.sol
@@ -59,7 +59,7 @@ contract TestIntegrationSupplyCollateral is IntegrationTest {
         assertEq(test.borrows.length, 0, "borrows.length");
 
         assertEq(morpho.supplyBalance(market.underlying, onBehalf), 0, "supply != 0");
-        assertApproxLeAbs(morpho.collateralBalance(market.underlying, onBehalf), amount, 1, "collateral != amount");
+        assertApproxLeAbs(morpho.collateralBalance(market.underlying, onBehalf), amount, 2, "collateral != amount");
 
         // Assert Morpho's position on pool.
         assertApproxEqAbs(

--- a/test/integration/TestIntegrationWETHGateway.sol
+++ b/test/integration/TestIntegrationWETHGateway.sol
@@ -52,7 +52,7 @@ contract TestIntegrationWETHGateway is IntegrationTest {
     }
 
     function testCannotSupplyETHWhenAmountIsZero(address onBehalf) public {
-        onBehalf = _boundAddressNotInvalid(onBehalf);
+        onBehalf = _boundAddressValid(onBehalf);
         assertEq(morpho.supplyBalance(weth, onBehalf), 0);
 
         vm.expectRevert(Errors.AmountIsZero.selector);
@@ -60,7 +60,7 @@ contract TestIntegrationWETHGateway is IntegrationTest {
     }
 
     function testSupplyETH(uint256 amount, address onBehalf) public {
-        onBehalf = _boundAddressNotInvalid(onBehalf);
+        onBehalf = _boundAddressValid(onBehalf);
         assertEq(morpho.supplyBalance(weth, onBehalf), 0);
 
         amount = bound(amount, MIN_AMOUNT, type(uint96).max);
@@ -76,7 +76,7 @@ contract TestIntegrationWETHGateway is IntegrationTest {
     }
 
     function testCannotSupplyCollateralETHWhenAmountIsZero(address onBehalf) public {
-        onBehalf = _boundAddressNotInvalid(onBehalf);
+        onBehalf = _boundAddressValid(onBehalf);
         assertEq(morpho.collateralBalance(weth, onBehalf), 0);
 
         vm.expectRevert(Errors.AmountIsZero.selector);
@@ -84,7 +84,7 @@ contract TestIntegrationWETHGateway is IntegrationTest {
     }
 
     function testSupplyCollateralETH(uint256 amount, address onBehalf) public {
-        onBehalf = _boundAddressNotInvalid(onBehalf);
+        onBehalf = _boundAddressValid(onBehalf);
         assertEq(morpho.collateralBalance(weth, onBehalf), 0);
 
         amount = bound(amount, MIN_AMOUNT, type(uint96).max);

--- a/test/internal/TestInternalEMode.sol
+++ b/test/internal/TestInternalEMode.sol
@@ -149,7 +149,7 @@ contract TestInternalEMode is InternalTest, PositionsManagerInternal {
         uint8 eModeCategoryId
     ) public {
         eModeCategoryId = uint8(bound(eModeCategoryId, 1, type(uint8).max));
-        priceSourceEMode = _boundAddressNotInvalid(priceSourceEMode);
+        priceSourceEMode = _boundAddressNotZero(priceSourceEMode);
         vm.assume(underlying != priceSourceEMode);
         underlyingPriceEMode = bound(underlyingPriceEMode, 1, type(uint256).max);
         underlyingPrice = bound(underlyingPrice, 0, type(uint256).max);
@@ -177,7 +177,7 @@ contract TestInternalEMode is InternalTest, PositionsManagerInternal {
         uint8 eModeCategoryId
     ) public {
         eModeCategoryId = uint8(bound(eModeCategoryId, 1, type(uint8).max));
-        underlying = _boundAddressNotInvalid(underlying);
+        underlying = _boundAddressNotZero(underlying);
         underlyingPriceEMode = bound(underlyingPriceEMode, 1, type(uint256).max);
         underlyingPrice = bound(underlyingPrice, 0, type(uint256).max);
 
@@ -203,7 +203,7 @@ contract TestInternalEMode is InternalTest, PositionsManagerInternal {
         uint256 underlyingPrice,
         uint8 eModeCategoryId
     ) public {
-        priceSourceEMode = _boundAddressNotInvalid(priceSourceEMode);
+        priceSourceEMode = _boundAddressNotZero(priceSourceEMode);
         vm.assume(underlying != priceSourceEMode);
         underlyingPriceEMode = bound(underlyingPriceEMode, 1, type(uint256).max);
         underlyingPrice = bound(underlyingPrice, 0, type(uint256).max);
@@ -229,7 +229,7 @@ contract TestInternalEMode is InternalTest, PositionsManagerInternal {
         uint8 eModeCategoryId
     ) public {
         eModeCategoryId = uint8(bound(eModeCategoryId, 1, type(uint8).max));
-        priceSourceEMode = _boundAddressNotInvalid(priceSourceEMode);
+        priceSourceEMode = _boundAddressNotZero(priceSourceEMode);
         vm.assume(underlying != priceSourceEMode);
         underlyingPrice = bound(underlyingPrice, 0, type(uint256).max);
 

--- a/test/internal/TestInternalMorphoInternal.sol
+++ b/test/internal/TestInternalMorphoInternal.sol
@@ -228,7 +228,7 @@ contract TestInternalMorphoInternal is InternalTest {
     }
 
     function testUpdateInDSWithSuppliers(address user, uint256 onPool, uint256 inP2P, bool head) public {
-        user = _boundAddressNotInvalid(user);
+        user = _boundAddressNotZero(user);
         onPool = bound(onPool, Constants.DUST_THRESHOLD + 1, type(uint96).max);
         inP2P = bound(inP2P, Constants.DUST_THRESHOLD + 1, type(uint96).max);
 
@@ -242,7 +242,7 @@ contract TestInternalMorphoInternal is InternalTest {
     }
 
     function testUpdateInDSWithBorrowers(address user, uint256 onPool, uint256 inP2P, bool head) public {
-        user = _boundAddressNotInvalid(user);
+        user = _boundAddressNotZero(user);
         onPool = bound(onPool, Constants.DUST_THRESHOLD + 1, type(uint96).max);
         inP2P = bound(inP2P, Constants.DUST_THRESHOLD + 1, type(uint96).max);
 
@@ -256,7 +256,7 @@ contract TestInternalMorphoInternal is InternalTest {
     }
 
     function testUpdateInDSWithDust(address user, uint256 onPool, uint256 inP2P, bool head) public {
-        user = _boundAddressNotInvalid(user);
+        user = _boundAddressNotZero(user);
         onPool = bound(onPool, 0, Constants.DUST_THRESHOLD);
         inP2P = bound(inP2P, 0, Constants.DUST_THRESHOLD);
 
@@ -277,7 +277,7 @@ contract TestInternalMorphoInternal is InternalTest {
     }
 
     function testUpdateSupplierInDS(address user, uint256 onPool, uint256 inP2P, bool head) public {
-        user = _boundAddressNotInvalid(user);
+        user = _boundAddressNotZero(user);
         onPool = bound(onPool, Constants.DUST_THRESHOLD + 1, type(uint96).max);
         inP2P = bound(inP2P, Constants.DUST_THRESHOLD + 1, type(uint96).max);
 
@@ -289,7 +289,7 @@ contract TestInternalMorphoInternal is InternalTest {
     }
 
     function testUpdateSupplierInDSWithDust(address user, uint256 onPool, uint256 inP2P, bool head) public {
-        user = _boundAddressNotInvalid(user);
+        user = _boundAddressNotZero(user);
         onPool = bound(onPool, 0, Constants.DUST_THRESHOLD);
         inP2P = bound(inP2P, 0, Constants.DUST_THRESHOLD);
 
@@ -301,7 +301,7 @@ contract TestInternalMorphoInternal is InternalTest {
     }
 
     function testUpdateBorrowerInDS(address user, uint256 onPool, uint256 inP2P, bool head) public {
-        user = _boundAddressNotInvalid(user);
+        user = _boundAddressNotZero(user);
         onPool = bound(onPool, Constants.DUST_THRESHOLD + 1, type(uint96).max);
         inP2P = bound(inP2P, Constants.DUST_THRESHOLD + 1, type(uint96).max);
 
@@ -314,7 +314,7 @@ contract TestInternalMorphoInternal is InternalTest {
     }
 
     function testUpdateBorrowerInDSWithDust(address user, uint256 onPool, uint256 inP2P, bool head) public {
-        user = _boundAddressNotInvalid(user);
+        user = _boundAddressNotZero(user);
         onPool = bound(onPool, 0, Constants.DUST_THRESHOLD);
         inP2P = bound(inP2P, 0, Constants.DUST_THRESHOLD);
 
@@ -334,7 +334,7 @@ contract TestInternalMorphoInternal is InternalTest {
         uint256 p2pSupplyIndex,
         bool head
     ) public {
-        user = _boundAddressNotInvalid(user);
+        user = _boundAddressNotZero(user);
         onPool = bound(onPool, Constants.DUST_THRESHOLD + 1, type(uint96).max);
         inP2P = bound(inP2P, Constants.DUST_THRESHOLD + 1, type(uint96).max);
         poolSupplyIndex = bound(poolSupplyIndex, MIN_INDEX, MAX_INDEX);
@@ -360,7 +360,7 @@ contract TestInternalMorphoInternal is InternalTest {
         uint256 p2pBorrowIndex,
         bool head
     ) public {
-        user = _boundAddressNotInvalid(user);
+        user = _boundAddressNotZero(user);
         onPool = bound(onPool, Constants.DUST_THRESHOLD + 1, type(uint96).max);
         inP2P = bound(inP2P, Constants.DUST_THRESHOLD + 1, type(uint96).max);
         poolBorrowIndex = bound(poolBorrowIndex, MIN_INDEX, MAX_INDEX);

--- a/test/internal/TestInternalPositionsManagerInternal.sol
+++ b/test/internal/TestInternalPositionsManagerInternal.sol
@@ -251,7 +251,7 @@ contract TestInternalPositionsManagerInternal is InternalTest, PositionsManagerI
 
     function testAuthorizeLiquidateShouldRevertIfSentinelDisallows(address borrower, uint256 healthFactor) public {
         _market[dai].isCollateral = true;
-        borrower = _boundAddressNotInvalid(borrower);
+        borrower = _boundAddressNotZero(borrower);
         healthFactor = bound(
             healthFactor,
             Constants.DEFAULT_LIQUIDATION_MIN_HF.percentAdd(1),
@@ -268,7 +268,7 @@ contract TestInternalPositionsManagerInternal is InternalTest, PositionsManagerI
 
     function testAuthorizeLiquidateShouldRevertIfBorrowerHealthy(address borrower, uint256 healthFactor) public {
         _market[dai].isCollateral = true;
-        borrower = _boundAddressNotInvalid(borrower);
+        borrower = _boundAddressNotZero(borrower);
         healthFactor = bound(healthFactor, Constants.DEFAULT_LIQUIDATION_MAX_HF.percentAdd(1), type(uint128).max);
 
         _setHealthFactor(borrower, dai, healthFactor);
@@ -281,7 +281,7 @@ contract TestInternalPositionsManagerInternal is InternalTest, PositionsManagerI
         public
     {
         _market[dai].isCollateral = true;
-        borrower = _boundAddressNotInvalid(borrower);
+        borrower = _boundAddressNotZero(borrower);
         healthFactor = bound(healthFactor, 0, Constants.DEFAULT_LIQUIDATION_MIN_HF.percentSub(1));
 
         _setHealthFactor(borrower, dai, healthFactor);
@@ -295,7 +295,7 @@ contract TestInternalPositionsManagerInternal is InternalTest, PositionsManagerI
         uint256 healthFactor
     ) public {
         _market[dai].isCollateral = true;
-        borrower = _boundAddressNotInvalid(borrower);
+        borrower = _boundAddressNotZero(borrower);
         healthFactor = bound(
             healthFactor,
             Constants.DEFAULT_LIQUIDATION_MIN_HF.percentAdd(1),


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request:

- fixes https://github.com/morpho-org/morpho-aave-v3/pull/869#discussion_r1238111497

This PR also highlights that `_boundAddressNotZero` was also renamed to `_boundAddressNotInvalid` in internal tests, which don't inherit from `IntegrationTest`, making the dev believe the behavior was blacklisting specific failing addresses whereas it's just discarding the zero address input